### PR TITLE
test: fix typo in test assertion error message

### DIFF
--- a/test_module.py
+++ b/test_module.py
@@ -36,7 +36,8 @@ class UnitTests(unittest.TestCase):
     def test_solutions(self):
         actual = arithmetic_arranger(["32 - 698", "1 - 3801", "45 + 43", "123 + 49"], True)
         expected = "   32         1      45      123\n- 698    - 3801    + 43    +  49\n-----    ------    ----    -----\n -666     -3800      88      172"
-        self.assertEqual(actual, expected, 'Expected solutions to be correctly displayed in output when calling "arithmetic_arranger()" with arithemetic problems and a second argument of `True`.')
+        self.assertEqual(actual, expected, 'Expected solutions to be correctly displayed in output when calling "arithmetic_arranger()" with arithmetic problems and a second argument of `True`.')
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Fixes typo in last test assertion error message.

```diff
- ... with arithemetic problems ...
+ ... with arithmetic problems ...
```