### PR TITLE
feat: use pytest for testing

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ Output:
 
 ### Rules
 
-The function will return the correct conversion if the supplied problems are properly formatted, otherwise, it will **return** a **string** that describes an error that is meaningful to the user.  
+The function will return the correct conversion if the supplied problems are properly formatted, otherwise, it will **return** a **string** that describes an error that is meaningful to the user.
 
 
 * Situations that will return an error:
@@ -60,9 +60,9 @@ The function will return the correct conversion if the supplied problems are pro
 
 Write your code in `arithmetic_arranger.py`. For development, you can use `main.py` to test your `arithmetic_arranger()` function. Click the "run" button and `main.py` will run.
 
-### Testing 
+### Testing
 
-The unit tests for this project are in `test_module.py`. We imported the tests from `test_module.py` to `main.py` for your convenience. The tests will run automatically whenever you hit the "run" button.
+The unit tests for this project are in `test_module.py`. We are running the tests from `test_module.py` in `main.py` for your convenience. The tests will run automatically whenever you hit the "run" button. Alternatively you may run tests with `pytest` in console.
 
 ### Submitting
 

--- a/main.py
+++ b/main.py
@@ -1,10 +1,11 @@
 # This entrypoint file to be used in development. Start by reading README.md
+from pytest import main
+
 from arithmetic_arranger import arithmetic_arranger
-from unittest import main
 
 
 print(arithmetic_arranger(["32 + 698", "3801 - 2", "45 + 43", "123 + 49"]))
 
 
 # Run unit tests automatically
-main(module='test_module', exit=False)
+main()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,15 @@
+[tool.poetry]
+name = "fcc-arithmetic-formatter"
+version = "0.1.0"
+description = ""
+authors = ["Your Name <you@example.com>"]
+
+[tool.poetry.dependencies]
+python = "^3.8"
+pytest = "^6.2.4"
+
+[tool.poetry.dev-dependencies]
+
+[build-system]
+requires = ["poetry-core>=1.0.0"]
+build-backend = "poetry.core.masonry.api"

--- a/test_module.py
+++ b/test_module.py
@@ -1,43 +1,55 @@
-import unittest
+import pytest
+
 from arithmetic_arranger import arithmetic_arranger
 
+test_cases = [
+    pytest.param(
+        [['3 + 855', '3801 - 2', '45 + 43', '123 + 49']],
+        '    3      3801      45      123\n'
+        '+ 855    -    2    + 43    +  49\n'
+        '-----    ------    ----    -----',
+        'Expected different output when calling "arithmetic_arranger()" with ["3 + 855", "3801 - 2", "45 + 43", "123 + 49"]',
+        id='test_arrangement1'),
+    pytest.param(
+        [['11 + 4', '3801 - 2999', '1 + 2', '123 + 49', '1 - 9380']],
+        '  11      3801      1      123         1\n'
+        '+  4    - 2999    + 2    +  49    - 9380\n'
+        '----    ------    ---    -----    ------',
+        'Expected different output when calling "arithmetic_arranger()" with ["11 + 4", "3801 - 2999", "1 + 2", "123 + 49", "1 - 9380"]',
+        id='test_arrangement2'),
+    pytest.param(
+        [['44 + 815', '909 - 2', '45 + 43', '123 + 49',
+          '888 + 40', '653 + 87']],
+        'Error: Too many problems.',
+        'Expected calling "arithmetic_arranger()" with more than five problems to return "Error: Too many problems."',
+        id='test_too_many_problems'),
+    pytest.param(
+        [['3 / 855', '3801 - 2', '45 + 43', '123 + 49']],
+        "Error: Operator must be '+' or '-'.",
+        '''Expected calling "arithmetic_arranger()" with a problem that uses the "/" operator to return "Error: Operator must be '+' or '-'."''',
+        id='test_incorrect_operator'),
+    pytest.param(
+        [['24 + 85215', '3801 - 2', '45 + 43', '123 + 49']],
+        'Error: Numbers cannot be more than four digits.',
+        'Expected calling "arithmetic_arranger()" with a problem that has a number over 4 digits long to return "Error: Numbers cannot be more than four digits."',
+        id='test_too_many_digits'),
+    pytest.param(
+        [['98 + 3g5', '3801 - 2', '45 + 43', '123 + 49']],
+        'Error: Numbers must only contain digits.',
+        'Expected calling "arithmetic_arranger()" with a problem that contains a letter character in the number to return "Error: Numbers must only contain digits."',
+        id='test_only_digits'),
+    pytest.param(
+        [['32 - 698', '1 - 3801', '45 + 43', '123 + 49'], True],
+        '   32         1      45      123\n'
+        '- 698    - 3801    + 43    +  49\n'
+        '-----    ------    ----    -----\n'
+        ' -666     -3800      88      172',
+        'Expected solutions to be correctly displayed in output when calling "arithmetic_arranger()" with arithmetic problems and a second argument of `True`.',
+        id='test_solutions'),
+]
 
-# the test case
-class UnitTests(unittest.TestCase):
-    def test_arrangement(self):
-        actual = arithmetic_arranger(["3 + 855", "3801 - 2", "45 + 43", "123 + 49"])
-        expected = "    3      3801      45      123\n+ 855    -    2    + 43    +  49\n-----    ------    ----    -----"
-        self.assertEqual(actual, expected, 'Expected different output when calling "arithmetic_arranger()" with ["3 + 855", "3801 - 2", "45 + 43", "123 + 49"]')
 
-        actual = arithmetic_arranger(["11 + 4", "3801 - 2999", "1 + 2", "123 + 49", "1 - 9380"])
-        expected = "  11      3801      1      123         1\n+  4    - 2999    + 2    +  49    - 9380\n----    ------    ---    -----    ------"
-        self.assertEqual(actual, expected, 'Expected different output when calling "arithmetic_arranger()" with ["11 + 4", "3801 - 2999", "1 + 2", "123 + 49", "1 - 9380"]')
-
-    def test_too_many_problems(self):
-        actual = arithmetic_arranger(["44 + 815", "909 - 2", "45 + 43", "123 + 49", "888 + 40", "653 + 87"])
-        expected = "Error: Too many problems."
-        self.assertEqual(actual, expected, 'Expected calling "arithmetic_arranger()" with more than five problems to return "Error: Too many problems."')
-
-    def test_incorrect_operator(self):
-        actual = arithmetic_arranger(["3 / 855", "3801 - 2", "45 + 43", "123 + 49"])
-        expected = "Error: Operator must be '+' or '-'."
-        self.assertEqual(actual, expected, '''Expected calling "arithmetic_arranger()" with a problem that uses the "/" operator to return "Error: Operator must be '+' or '-'."''')
-        
-    def test_too_many_digits(self):
-        actual = arithmetic_arranger(["24 + 85215", "3801 - 2", "45 + 43", "123 + 49"])
-        expected = "Error: Numbers cannot be more than four digits."
-        self.assertEqual(actual, expected, 'Expected calling "arithmetic_arranger()" with a problem that has a number over 4 digits long to return "Error: Numbers cannot be more than four digits."')
-
-    def test_only_digits(self):
-        actual = arithmetic_arranger(["98 + 3g5", "3801 - 2", "45 + 43", "123 + 49"])
-        expected = "Error: Numbers must only contain digits."
-        self.assertEqual(actual, expected, 'Expected calling "arithmetic_arranger()" with a problem that contains a letter character in the number to return "Error: Numbers must only contain digits."')
-
-    def test_solutions(self):
-        actual = arithmetic_arranger(["32 - 698", "1 - 3801", "45 + 43", "123 + 49"], True)
-        expected = "   32         1      45      123\n- 698    - 3801    + 43    +  49\n-----    ------    ----    -----\n -666     -3800      88      172"
-        self.assertEqual(actual, expected, 'Expected solutions to be correctly displayed in output when calling "arithmetic_arranger()" with arithmetic problems and a second argument of `True`.')
-
-
-if __name__ == "__main__":
-    unittest.main()
+@pytest.mark.parametrize('arguments,expected_output,fail_message', test_cases)
+def test_template(arguments, expected_output, fail_message):
+    actual = arithmetic_arranger(*arguments)
+    assert actual == expected_output, fail_message


### PR DESCRIPTION
- Adds `pyproject.toml` file, for poetry dependency manager, to install pytest module.
- Changes `main.py` file to run tests with pytest instead of unittest module.
- Slightly adjusts `README.md`.
- Changes `test_module.py` to use standard pytest syntax. Because all the tests were doing basically the same, just with different input/output, I've decided to leverage the pytest's parametrize feature and re-use single test with different parameters. Note this affects the output minimally, as pytest is quite clever about it.
- Project with changed testing can be found at https://replit.com/@sanityto/arithmetic-formatter-with-pytest, I've used code from the linked issue. Note it shows 3 fails (instead of 2 as before), because previously both arrangements assertions were in a single test.

Checklist:

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)

Closes https://github.com/freeCodeCamp/freeCodeCamp/issues/43051